### PR TITLE
Follow the Best Practice

### DIFF
--- a/airflow-deployment.yaml
+++ b/airflow-deployment.yaml
@@ -13,7 +13,8 @@ spec:
     spec:
       containers:
       - name: web
-        image: kysnm/docker-airflow:latest
+        image: kysnm/docker-airflow:1.10.2
+        imagePullPolicy: Always
         readinessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
https://v1-10.docs.kubernetes.io/docs/concepts/configuration/overview/#container-images

> You should avoid using the :latest tag when deploying containers in production, because this makes it hard to track which version of the image is running and hard to roll back.